### PR TITLE
Fix the release error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,6 @@ jobs:
       uses: goreleaser/goreleaser-action@v2
       with:
         version: latest
-        args: release --rm-dist
+        args: release --clean
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,6 @@
 # This is an example .goreleaser.yml file with some sensible defaults.
 # Make sure to check the documentation at https://goreleaser.com
+version: 2
 before:
   hooks:
     # You may remove this if you don't use go modules.

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,7 +26,7 @@ archives:
       {{- else }}{{ .Arch }}{{ end }}
     format_overrides:
       - goos: windows
-        format: zip
+        formats: zip
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,7 +30,7 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
   filters:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,12 +17,13 @@ builds:
     ldflags:
       - -w -s -X main.appVersion={{.Version}} -X main.appRevision={{.ShortCommit}}
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+  - name_template: >-
+      {{- .ProjectName }}_
+      {{- .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
     format_overrides:
       - goos: windows
         format: zip


### PR DESCRIPTION
## Problem

The release v0.4.0 failed.

https://github.com/sheepla/qiitaz/releases/tag/v0.4.0

No asset was released.

<img width="242" alt="image" src="https://github.com/user-attachments/assets/f544a376-c96b-4ca6-8b4a-e14cc840556c" />

The release workflow failed.

https://github.com/sheepla/qiitaz/actions/runs/13642969743/job/38136539923

```
Run goreleaser/goreleaser-action@v2
Downloading https://github.com/goreleaser/goreleaser/releases/download/v2.7.0/goreleaser_Linux_x86_64.tar.gz
Extracting GoReleaser
/usr/bin/tar xz --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/2ef527ca-ab8c-4ad7-8586-b54f3378f8ba -f /home/runner/work/_temp/cef4337c-439a-4ba0-9496-6addd193e966
GoReleaser latest installed successfully
v0.4.0 tag found for commit 'c8da471'
/opt/hostedtoolcache/goreleaser-action/2.7.0/x64/goreleaser release --rm-dist
  ⨯ command failed                                   error=unknown flag: --rm-dist
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.7.0/x64/goreleaser' failed with exit code 1
```

## What

- **ci: replace --rm-dist with --clean**
- **chore(goreleaser): specify version**
- **chore: replace replacements with name_template**
- **chore: replace format_overrides.format with format_overrides.formats**
- **chore: replace snapshot.name_template with version_template**

`--rm-dist` was deprecated.
So this pull request replaces it with `--clean`.

Furthermore, this pull request fixes deprecation warnings of .goreleaser.yaml.

https://goreleaser.com/deprecations/

## Test

### goreleaser check

Before:

```console
$ goreleaser check
  • only  version: 2  configuration files are supported, yours is  version: 0 , please update your configuration
  ⨯ command failed                                   error=only  version: 2  configuration files are supported, yours is  version: 0 , please update your configuration
```

After:

```console
$ goreleaser check
  • checking                                 path=.goreleaser.yaml
  • 1 configuration file(s) validated
  • thanks for using GoReleaser!
```

### Release test

https://github.com/suzuki-shunsuke/qiitaz/actions/runs/13643335528/job/38137585398
https://github.com/suzuki-shunsuke/qiitaz/releases/tag/v0.4.1-0

The release succeeded.
And the format of asset names isn't changed.

Before:

```console
$ gh release view --json assets --jq ".assets[].name" -R sheepla/qiitaz v0.3.0
checksums.txt
qiitaz_0.3.0_Darwin_arm64.tar.gz
qiitaz_0.3.0_Darwin_x86_64.tar.gz
qiitaz_0.3.0_Linux_arm64.tar.gz
qiitaz_0.3.0_Linux_i386.tar.gz
qiitaz_0.3.0_Linux_x86_64.tar.gz
qiitaz_0.3.0_Windows_arm64.zip
qiitaz_0.3.0_Windows_i386.zip
qiitaz_0.3.0_Windows_x86_64.zip
```

After:

```console
$ gh release view --json assets --jq ".assets[].name" -R suzuki-shunsuke/qiitaz v0.4.1-0
checksums.txt
qiitaz_0.4.1-0_Darwin_arm64.tar.gz
qiitaz_0.4.1-0_Darwin_x86_64.tar.gz
qiitaz_0.4.1-0_Linux_arm64.tar.gz
qiitaz_0.4.1-0_Linux_i386.tar.gz
qiitaz_0.4.1-0_Linux_x86_64.tar.gz
qiitaz_0.4.1-0_Windows_arm64.zip
qiitaz_0.4.1-0_Windows_i386.zip
qiitaz_0.4.1-0_Windows_x86_64.zip
```